### PR TITLE
Rename project to RScreenFlash branding

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
 
-namespace ScreenshotFlash
+namespace RScreenFlash
 {
     static class Program
     {

--- a/RScreenFlash.csproj
+++ b/RScreenFlash.csproj
@@ -6,8 +6,8 @@
     <ProductVersion>10.0.20506</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputType>WinExe</OutputType>
-    <StartupObject>ScreenshotFlash.Program</StartupObject>
-    <RootNamespace>ScreenshotFlash</RootNamespace>
+    <StartupObject>RScreenFlash.Program</StartupObject>
+    <RootNamespace>RScreenFlash</RootNamespace>
     <AssemblyName>RScreenFlash</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <ProjectGuid>{AA56E68A-0248-B00F-0561-990CED36BC73}</ProjectGuid>

--- a/RScreenFlash.sln
+++ b/RScreenFlash.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.13.35919.96
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScreenshotFlash", "ScreenshotFlash.csproj", "{AA56E68A-0248-B00F-0561-990CED36BC73}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RScreenFlash", "RScreenFlash.csproj", "{AA56E68A-0248-B00F-0561-990CED36BC73}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/SelectionForm.cs
+++ b/SelectionForm.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
-namespace ScreenshotFlash
+namespace RScreenFlash
 {
     public class SelectionForm : Form
     {


### PR DESCRIPTION
## Summary
- rename the solution, project file, and namespaces to RScreenFlash for consistent branding

## Testing
- dotnet build RScreenFlash.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e7a6f4b52c832297e1a8ed6712bdbb